### PR TITLE
Update sqerl for latest epgsql/epgsql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ otp_release:
   - R16B03
   - R16B02
   - R16B01
-  - R15B03
 
 addons:
   postgresql: "9.3"

--- a/src/sqerl_pgsql_errors.erl
+++ b/src/sqerl_pgsql_errors.erl
@@ -20,7 +20,7 @@
 %% @doc Translates Postgres error codes into human-friendly error tuples
 -module(sqerl_pgsql_errors).
 
--include_lib("epgsql/include/pgsql.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 
 -export([translate/1,
          translate_code/1]).


### PR DESCRIPTION
Recent changes to `epgsql/epgsql` have changed the namespace from `pgsql` to `epgsql`. This PR tracks those changes so that downstream consumers of `sqerl` can make new releases without locking `epgsql` unnecessarily. 