### PR TITLE
Pin back to chef org

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 {deps, [
         %% This is until a patch of ours gets merged into the main epgsql repo
         {epgsql, ".*",
-         {git, "git://github.com/epgsql/epgsql.git", "master"}},
+         {git, "git://github.com/chef/epgsql-1.git", "master"}},
 
         {pooler, ".*",
          {git, "git://github.com/seth/pooler.git", {tag, "1.3.3"}}},


### PR DESCRIPTION
Delivery needs the int4range type. A pr has been opened and merged against
epgsql/epgsql. That PR was not merged to master but rather a devel branch
that is currently unreleased.

Until the devel branch is actually released, we need to pin back to the
chef organization epgsql. It should only be a few commits ahead of master
and we will pin back once epgsql releases.