### PR TITLE
use wire message pipelining via execute_batch

### DIFF
--- a/cover.spec
+++ b/cover.spec
@@ -1,4 +1,0 @@
-{incl_app, sqerl, details}.
-{src_dirs, sqerl, ["src"]}.
-{incl_dirs_r, ["src"]}.
-

--- a/cover.spec
+++ b/cover.spec
@@ -1,0 +1,4 @@
+{incl_app, sqerl, details}.
+{src_dirs, sqerl, ["src"]}.
+{incl_dirs_r, ["src"]}.
+

--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 {deps, [
         %% This is until a patch of ours gets merged into the main epgsql repo
         {epgsql, ".*",
-         {git, "git://github.com/chef/epgsql-1.git", "master"}},
+         {git, "git://github.com/chef/epgsql-1.git", {branch, "master"}}},
 
         {pooler, ".*",
          {git, "git://github.com/seth/pooler.git", {tag, "1.3.3"}}},
@@ -23,8 +23,7 @@
          {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
        ]}.
 
-{dev_only_deps,
- []}.
+{dev_only_deps, []}.
 
 {cover_enabled, true}.
 

--- a/src/sqerl.erl
+++ b/src/sqerl.erl
@@ -113,6 +113,9 @@ statement(StmtName, StmtArgs, XformName, XformArgs) ->
             {ok, none};
         {ok, N} when is_number(N) ->
             {ok, N};
+        % response from execute of raw sql
+        {ok, {N, Rows}} when is_number(N) ->
+            {ok, N, Rows};
         {ok, N, Rows} when is_number(N) ->
             {ok, N, Rows};
         {error, Reason} ->
@@ -396,11 +399,14 @@ parse_error(Reason) ->
 
 -spec parse_error(pgsql,
                   'no_connections' |
+                  {'error', 'error', _, _, _} |
                   {'error', {'error', _, _, _, _}}) -> sqerl_error().
 parse_error(_DbType, no_connections) ->
     {error, no_connections};
 parse_error(_DbType, {error, Reason} = Error) when is_atom(Reason) ->
     Error;
+parse_error(pgsql, {error, error, Code, Message, _Extra}) ->
+    do_parse_error({Code, Message}, ?PGSQL_ERROR_CODES);
 parse_error(pgsql, {error,               % error from sqerl
                     {error,              % error record marker from epgsql
                      _Severity,          % Severity


### PR DESCRIPTION
This encompasses a three of changes: 

1) execute_batch instead of execute, 
2) update response handling for the different response types of execute_batch 
3) remove epgsql:sync calls where they are no longer required. ( in one case, it was not required before this change either.) 
4) ~~add cover.spec for CT~~ rebar not supporting this, rolled it back