### PR TITLE
add cinsert/1 for inserts stmts that return a count

### DIFF
--- a/test/cook.erl
+++ b/test/cook.erl
@@ -56,7 +56,11 @@
      {fetch_null_last_names,
       ["SELECT id, kitchen_id, name, auth_token, auth_token_bday, ",
        "ssh_pub_key, first_name, last_name, email FROM cookers "
-       "WHERE last_name IS NULL AND kitchen_id = $1"]}].
+       "WHERE last_name IS NULL AND kitchen_id = $1"]},
+     {update_email_to_null, ["update cookers set email=null"]},
+     {update_all_emails, ["update cookers set email=$1"]},
+     {fetch_null_emails, ["select * from cookers where email is null"]}
+    ].
 
 '#table_name'() ->
     "cookers".

--- a/test/sqerl_rec_tests.erl
+++ b/test/sqerl_rec_tests.erl
@@ -157,6 +157,11 @@ kitchen_test_() ->
                               "query did not return a single column",
                               [kitchen, fetch_all, []]}}},
                             sqerl_rec:scalar_fetch(kitchen, fetch_all, []))
+       end},
+      {"cinsert",
+       fun() ->
+               {K0, _Name} = make_kitchen(<<"pingpang">>),
+               {ok, 1} = sqerl_rec:cinsert(K0)
        end}
      ]}.
 


### PR DESCRIPTION
Needed for tables managed by pg_partman.

Additionally, `cquery/3` now converts undefined values to null

See also https://github.com/chef/chef-analytics/pull/83