### PR TITLE
Erlang 18 compat fixes

### DIFF
--- a/common_test/sqerl_integration_SUITE.erl
+++ b/common_test/sqerl_integration_SUITE.erl
@@ -443,7 +443,7 @@ adhoc_insert(Config) ->
     end(),
     ok.
 
-insert_select_gzip_data(Config) ->
+insert_select_gzip_data(_Config) ->
     Text = <<"data to compress with gzip">>,
     GzipData = zlib:gzip(Text),
     Row = [{last_name, <<"gzip">>}, {datablob, GzipData}],

--- a/common_test/sqerl_perf_SUITE.erl
+++ b/common_test/sqerl_perf_SUITE.erl
@@ -21,7 +21,6 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
--include("sqerl.hrl").
 
 -compile([export_all]).
 
@@ -33,7 +32,7 @@ init_per_testcase(_, Config) ->
     pgsql_test_buddy:setup_env(),
     Config.
 
-perf_test(Config) ->
+perf_test(_Config) ->
     adhoc_insert(10000, 1),
     adhoc_insert(10000, 10),
     adhoc_insert(10000, 100),

--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
          {git, "git://github.com/chef/epgsql-1.git", {branch, "master"}}},
 
         {pooler, ".*",
-         {git, "git://github.com/seth/pooler.git", {tag, "1.3.3"}}},
+         {git, "git://github.com/seth/pooler.git", {tag, "1.5.0"}}},
 
         {envy, ".*",
          {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -61,7 +61,7 @@ EDown = case proplists:get_value(use_edown, CONFIG) of
                 [DocOpts,
                  {deps,
                   [{edown, ".*",
-                    {git, "git://github.com/seth/edown.git",
+                    {git, "git://github.com/uwiger/edown.git",
                      {branch, "master"}}}]}]
            end,
 

--- a/test/sqerl_rec_tests.erl
+++ b/test/sqerl_rec_tests.erl
@@ -20,7 +20,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 make_name(Prefix) ->
-    V = io_lib:format("~B.~B.~B", erlang:tuple_to_list(erlang:now())),
+    V = io_lib:format("~B.~B.~B", erlang:tuple_to_list(os:timestamp())),
     erlang:iolist_to_binary([Prefix, V]).
 
 statements_test_() ->


### PR DESCRIPTION
These patches allow sqerl to be compiled and (mostly) tested on Erlang 18. Dialyzer is unable to run because (at least our fork of) epgsql has a dialyzer type definition error:

```
dialyzer: Analysis failed with error:
epgsql_geometry.hrl:97: Illegal declaration of #multi_surface{point_type}
```

