### PR TITLE
Add new req_timeout parameter to epgsql connection.

### DIFF
--- a/src/sqerl_pgsql_client.erl
+++ b/src/sqerl_pgsql_client.erl
@@ -189,7 +189,13 @@ init(Config) ->
     {timeout, Timeout} = lists:keyfind(timeout, 1, Config),
     {db, Db} = lists:keyfind(db, 1, Config),
     {prepared_statements, Statements} = lists:keyfind(prepared_statements, 1, Config),
-    Opts = [{database, Db}, {port, Port}, {timeout, Timeout}],
+    %% req_timeout indicates how long the client side will wait for a request to complete.
+    %% It is set to the same as statement timeout (default_timeout in state) +250ms to provide time for
+    %% wire latency in a server-side cancel.  Postgres will get back to us to either cancel or finish the
+    %% request in that time frame. Setting a slightly
+    %% higher req_timeout ensures that when we've lost connectivity to postgres, we give up on the request
+    %% and mark the connection as invalid.
+    Opts = [{database, Db}, {port, Port}, {timeout, Timeout}, {req_timeout, Timeout + 100}],
     CTrans =
         case lists:keyfind(column_transforms, 1, Config) of
             {column_transforms, CT} -> CT;


### PR DESCRIPTION
This enables (simulated) socket level timeout - tcp can't give it to us,
but erlang can. When req_timeout is set, the epgsql postgres connection
will monitor when it is expected to receive a reply, and terminate the
connectoin with {error, timeout} when it is not received before
(approximately) req_timeout.

Note: the rebar.config update is a temporary change until PR https://github.com/chef/epgsql-1/pull/8 is merged.


Signed-off-by: Marc Paradise <marc@chef.io>