### PR TITLE
Add a callback module for injecting config by other means

### DIFF
--- a/src/sqerl_client.erl
+++ b/src/sqerl_client.erl
@@ -119,22 +119,10 @@ start_link(DbType) ->
     gen_server:start_link(?MODULE, [DbType], []).
 
 init([]) ->
-    init(drivermod());
-init(CallbackMod) ->
-    IdleCheck = envy:get(sqerl,idle_check, 1000, non_neg_integer),
+    init(drivermod(), config()).
 
-    Statements = read_statements_from_config(),
-
-    %% The ip_mode key in the sqerl clause determines if we parse db_host as IPv4 or IPv6
-    Config = [{host, envy_parse:host_to_ip(sqerl, db_host)},
-              {port, envy:get(sqerl, db_port, pos_integer)},
-              {user, envy:get(sqerl, db_user, string)},
-              {pass, envy:get(sqerl, db_pass, string)},
-              {db, envy:get(sqerl, db_name, string)},
-              {timeout, envy:get(sqerl,db_timeout, 5000, pos_integer)},
-              {idle_check, IdleCheck},
-              {prepared_statements, Statements},
-              {column_transforms, envy:get(sqerl, column_transforms, list)}],
+init(CallbackMod, Config) ->
+    IdleCheck = proplists:get_value(idle_check, Config),
     case CallbackMod:init(Config) of
         {ok, CallbackState} ->
             {ok, #state{cb_mod=CallbackMod, cb_state=CallbackState,
@@ -177,23 +165,6 @@ exec_driver({Call, QueryOrName, Args}, _From, #state{cb_mod=CBMod, cb_state=CBSt
     {Result, NewCBState} = apply(CBMod, Call, [QueryOrName, Args, CBState]),
     ?LOG_RESULT(Result),
     {reply, Result, State#state{cb_state=NewCBState}, Timeout}.
-
-
-%% @doc Prepared statements can be provides as a list of `{atom(), binary()}' tuples, as a
-%% path to a file that can be consulted for such tuples, or as `{M, F, A}' such that
-%% `apply(M, F, A)' returns the statements tuples.
--spec read_statements([{atom(), term()}]
-                      | string()
-                      | {atom(), atom(), list()})
-                     -> [{atom(), binary()}].
-read_statements({Mod, Fun, Args}) ->
-    apply(Mod, Fun, Args);
-read_statements(L = [{Label, SQL}|_T]) when is_atom(Label) andalso is_binary(SQL) ->
-    L;
-read_statements(Path) when is_list(Path) ->
-    {ok, Statements} = file:consult(Path),
-    Statements.
-
 
 
 %% @doc Returns SQL parameter style atom, e.g. qmark, dollarn.
@@ -241,19 +212,29 @@ drivermod() ->
             log_and_error({invalid_application_config, sqerl, db_driver_mod, Error})
     end.
 
+%% @doc Returns the config, based on configured config_cb MFA. Defaults to
+%% using sqerl_config_env:config/0, which will use the application environment.
+-spec config() -> [{atom(), term()}].
+config() ->
+    {M, F, A} = case envy:get(sqerl, config_cb, undefined, any) of
+        undefined ->
+            {sqerl_config_env, config, []};
+        {Mod, Fun, Args} = MFA when is_atom(Mod) andalso
+                                    is_atom(Fun) andalso
+                                    is_list(Args) ->
+            case code:which(Mod) of
+                non_existing ->
+                    log_and_error({does_not_exist, sqerl, config_cb, Mod});
+                _  ->
+                    MFA
+            end;
+        Error ->
+            log_and_error({invalid_application_config, sqerl, config_cb, Error})
+    end,
+    erlang:apply(M, F, A).
+
 %% Helper function to report and error
 
 log_and_error(Msg) ->
     error_logger:error_report(Msg),
     error(Msg).
-
-read_statements_from_config() ->
-    StatementSource = envy:get(sqerl, prepared_statements, any),
-    try
-        read_statements(StatementSource)
-    catch
-        error:Reason ->
-            Msg = {incorrect_application_config, sqerl, {prepared_statements, Reason, erlang:get_stacktrace()}},
-            error_logger:error_report(Msg),
-            error(Msg)
-    end.

--- a/src/sqerl_config_env.erl
+++ b/src/sqerl_config_env.erl
@@ -1,0 +1,68 @@
+%% @doc Module fetching sqerl configuration from application environment using
+%%      envy.
+%% Copyright 2017 CHEF Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(sqerl_config_env).
+
+-export([config/0]).
+
+%% utility exports
+-export([read_statements_from_config/0]).
+
+-spec config() -> [{atom(), term()}].
+config() ->
+    IdleCheck = envy:get(sqerl, idle_check, 1000, non_neg_integer),
+
+    Statements = read_statements_from_config(),
+
+    %% The ip_mode key in the sqerl clause determines if we parse db_host as IPv4 or IPv6
+    [{host, envy_parse:host_to_ip(sqerl, db_host)},
+     {port, envy:get(sqerl, db_port, pos_integer)},
+     {user, envy:get(sqerl, db_user, string)},
+     {pass, envy:get(sqerl, db_pass, string)},
+     {db, envy:get(sqerl, db_name, string)},
+     {timeout, envy:get(sqerl,db_timeout, 5000, pos_integer)},
+     {idle_check, IdleCheck},
+     {prepared_statements, Statements},
+     {column_transforms, envy:get(sqerl, column_transforms, list)}].
+
+%% @doc Prepared statements can be provides as a list of `{atom(), binary()}' tuples, as a
+%% path to a file that can be consulted for such tuples, or as `{M, F, A}' such that
+%% `apply(M, F, A)' returns the statements tuples.
+-spec read_statements([{atom(), term()}]
+                      | string()
+                      | {atom(), atom(), list()})
+                     -> [{atom(), binary()}].
+read_statements({Mod, Fun, Args}) ->
+    apply(Mod, Fun, Args);
+read_statements(L = [{Label, SQL}|_T]) when is_atom(Label) andalso is_binary(SQL) ->
+    L;
+read_statements(Path) when is_list(Path) ->
+    {ok, Statements} = file:consult(Path),
+    Statements.
+
+read_statements_from_config() ->
+    StatementSource = envy:get(sqerl, prepared_statements, any),
+    try
+        read_statements(StatementSource)
+    catch
+        error:Reason ->
+            Msg = {incorrect_application_config, sqerl, {prepared_statements, Reason, erlang:get_stacktrace()}},
+            error_logger:error_report(Msg),
+            error(Msg)
+    end.

--- a/test/sqerl_client_tests.erl
+++ b/test/sqerl_client_tests.erl
@@ -1,0 +1,88 @@
+%% Copyright 2017 CHEF Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(sqerl_client_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-compile([export_all]).
+
+-define(DB_HOST, "localhost").
+-define(DB_PORT, 5432).
+-define(DB_USER, "elmo").
+-define(DB_PASS, "sesame").
+-define(DB_NAME, "street").
+-define(DB_TIMEOUT, 200).
+-define(COLUMN_TRANSFORMS, []).
+-define(IDLE_CHECK, 201).
+
+-define(EXPECTED_CONFIG, [{idle_check, ?DB_TIMEOUT}]).
+config(args) -> ?EXPECTED_CONFIG.
+
+%% for first test case
+init(?EXPECTED_CONFIG) -> {ok, expected_driver_state};
+%% for second test case
+init(Config) ->
+    [
+     ?assertEqual(Expected, proplists:get_value(Key, Config)) ||
+                  {Expected, Key} <- [{?DB_USER, user},
+                                      {?DB_NAME, db},
+                                      {?DB_TIMEOUT, timeout},
+                                      {?DB_PORT, port},
+                                      {?IDLE_CHECK, idle_check},
+                                      %% host_to_ip special treatment
+                                      {{127,0,0,1}, host}
+                                     ]
+    ],
+    {ok, expected_driver_state}.
+
+-record(state, {cb_mod,
+                cb_state,
+                timeout = 5000 :: pos_integer()}).
+
+init_fetches_driver_mod_and_config_mod_from_env_and_calls_them_test() ->
+    application:set_env(sqerl, db_driver_mod, ?MODULE),
+    application:set_env(sqerl, config_cb, {?MODULE, config, [args]}),
+    Actual = sqerl_client:init([]),
+    ExpectedState = #state{cb_mod = ?MODULE,
+                           cb_state = expected_driver_state,
+                           timeout = ?DB_TIMEOUT},
+    ?assertEqual({ok, ExpectedState, ?DB_TIMEOUT}, Actual),
+    cleanup_env().
+
+init_when_using_default_config_mod_uses_application_environment_to_get_configuration_values_test() ->
+    application:set_env(sqerl, db_driver_mod, ?MODULE),
+    application:unset_env(sqerl, config_cb),
+    application:set_env(sqerl, db_host, ?DB_HOST),
+    application:set_env(sqerl, db_port, ?DB_PORT),
+    application:set_env(sqerl, db_user, ?DB_USER),
+    application:set_env(sqerl, db_pass, ?DB_PASS),
+    application:set_env(sqerl, db_name, ?DB_NAME),
+    application:set_env(sqerl, db_timeout, ?DB_TIMEOUT),
+    application:set_env(sqerl, column_transforms, ?COLUMN_TRANSFORMS),
+    application:set_env(sqerl, prepared_statements, {sqerl_rec, statements, [[kitchen, cook]]}),
+    application:set_env(sqerl, idle_check, ?IDLE_CHECK),
+    Actual = sqerl_client:init([]),
+    ExpectedState = #state{cb_mod = ?MODULE,
+                           cb_state = expected_driver_state,
+                           timeout = ?IDLE_CHECK},
+    ?assertEqual({ok, ExpectedState, ?IDLE_CHECK}, Actual),
+    cleanup_env().
+
+cleanup_env() ->
+    application:unset_env(sqerl, config_cb),
+    application:unset_env(sqerl, db_driver_mod).


### PR DESCRIPTION
...defaulting to what it was doing before: using envy:get/4 to fetch
it from the app environment.