### PR TITLE
allow extra options to be passed to epgsql:connect

### DIFF
--- a/src/sqerl_config_env.erl
+++ b/src/sqerl_config_env.erl
@@ -36,6 +36,7 @@ config() ->
      {user, envy:get(sqerl, db_user, string)},
      {pass, envy:get(sqerl, db_pass, string)},
      {db, envy:get(sqerl, db_name, string)},
+     {extra_options, envy:get(sqerl, db_options, [], list)},
      {timeout, envy:get(sqerl,db_timeout, 5000, pos_integer)},
      {idle_check, IdleCheck},
      {prepared_statements, Statements},

--- a/src/sqerl_pgsql_client.erl
+++ b/src/sqerl_pgsql_client.erl
@@ -189,10 +189,7 @@ init(Config) ->
     {timeout, Timeout} = lists:keyfind(timeout, 1, Config),
     {db, Db} = lists:keyfind(db, 1, Config),
     {prepared_statements, Statements} = lists:keyfind(prepared_statements, 1, Config),
-    ExtraOptions = case lists:keyfind(extra_options, 1, Config) of
-                       {extra_options, EO} -> EO;
-                       false -> []
-                   end,
+    {extra_options, ExtraOptions}  = lists:keyfind(extra_options, 1, Config),
     %% req_timeout indicates how long the client side will wait for a request to complete.
     %% It is set to the same as statement timeout (default_timeout in state) +250ms to provide time for
     %% wire latency in a server-side cancel.  Postgres will get back to us to either cancel or finish the

--- a/src/sqerl_pgsql_client.erl
+++ b/src/sqerl_pgsql_client.erl
@@ -189,13 +189,21 @@ init(Config) ->
     {timeout, Timeout} = lists:keyfind(timeout, 1, Config),
     {db, Db} = lists:keyfind(db, 1, Config),
     {prepared_statements, Statements} = lists:keyfind(prepared_statements, 1, Config),
+    ExtraOptions = case lists:keyfind(extra_options, 1, Config) of
+                       {extra_options, EO} -> EO;
+                       false -> []
+                   end,
     %% req_timeout indicates how long the client side will wait for a request to complete.
     %% It is set to the same as statement timeout (default_timeout in state) +250ms to provide time for
     %% wire latency in a server-side cancel.  Postgres will get back to us to either cancel or finish the
     %% request in that time frame. Setting a slightly
     %% higher req_timeout ensures that when we've lost connectivity to postgres, we give up on the request
     %% and mark the connection as invalid.
-    Opts = [{database, Db}, {port, Port}, {timeout, Timeout}, {req_timeout, Timeout + 100}],
+    Opts = [ {database, Db},
+             {port, Port},
+             {timeout, Timeout},
+             {req_timeout, Timeout + 100}
+             | ExtraOptions ],
     CTrans =
         case lists:keyfind(column_transforms, 1, Config) of
             {column_transforms, CT} -> CT;


### PR DESCRIPTION
this allows us to set things like ssl options via the config:
* https://github.com/epgsql/epgsql#connect

Signed-off-by: Stephen Delano <stephen@chef.io>