### PR TITLE
Make extra options optional

### DIFF
--- a/src/sqerl_pgsql_client.erl
+++ b/src/sqerl_pgsql_client.erl
@@ -189,7 +189,7 @@ init(Config) ->
     {timeout, Timeout} = lists:keyfind(timeout, 1, Config),
     {db, Db} = lists:keyfind(db, 1, Config),
     {prepared_statements, Statements} = lists:keyfind(prepared_statements, 1, Config),
-    {extra_options, ExtraOptions}  = lists:keyfind(extra_options, 1, Config),
+    ExtraOptions  = proplists:get_value(extra_options, Config, []),
     %% req_timeout indicates how long the client side will wait for a request to complete.
     %% It is set to the same as statement timeout (default_timeout in state) +250ms to provide time for
     %% wire latency in a server-side cancel.  Postgres will get back to us to either cancel or finish the


### PR DESCRIPTION
We're doing this because the version of sqerl that chef-server has tests that doesn't pass in a Config with `extra_options`. That means bringing in the master of sqerl and fix the tests, however I think this is more correct because the intention of `extra_options` is that we'll use them if they're available and you shouldn't have to specify an `[]`.