### PR TITLE
Add verify_ca TLS verify mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: erlang
 
+branches:
+  only:
+    - "master"
+
 otp_release:
   - 21.0
   - 19.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ otp_release:
   - 17.0 # 17.5 concrete PLT has some issues; dig into them
 
 addons:
-  postgresql: "9.3"
+  postgresql: 9.6
 
 install: true
 


### PR DESCRIPTION
In older versions of Erlang, verify_peer didn't validate hostnames in
many cases. However, since Erlang 19+, it validates hostnames in many
more cases.

While we generally like our hostnames validated, for SQL in
particular, this can be problematic as we are sometimes connected via
an IP that doesn't match the certificate on the server.

This change allows the user to specify `verify_ca` as the verify mode
to mimick the `verify-ca` PG URL option. In this mode, all normal
verification is done, but hostname_check_failed errors are ignored.

https://www.postgresql.org/docs/9.6/libpq-ssl.html

Signed-off-by: Steven Danna <steve@chef.io>