### PR TITLE
Use chef/pooler, not seth/pooler

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
          {git, "git://github.com/chef/epgsql-1.git", {branch, "master"}}},
 
         {pooler, ".*",
-         {git, "git://github.com/seth/pooler.git", {branch, "master"}}},
+         {git, "git://github.com/chef/pooler.git", {branch, "master"}}},
 
         {envy, ".*",
          {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}


### PR DESCRIPTION
Signed-off-by: Lincoln Baker <lbaker@chef.io>

Use chef/pooler, not seth/pooler.

## Tests

https://buildkite.com/chef/chef-chef-server-master-verify/builds/3343#73e267e4-f404-4fc0-a615-f54b89fb0919
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/2232#e8f7a1cc-f2db-44f7-a98a-1c6db8ebcee7

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
