### PR TITLE
Update the dependencies to use https

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,13 +17,13 @@
 {deps, [
         %% This is until a patch of ours gets merged into the main epgsql repo
         {epgsql, ".*",
-         {git, "git://github.com/chef/epgsql-1.git", {branch, "master"}}},
+         {git, "https://github.com/chef/epgsql-1.git", {branch, "master"}}},
 
         {pooler, ".*",
-         {git, "git://github.com/chef/pooler.git", {branch, "master"}}},
+         {git, "https://github.com/chef/pooler.git", {branch, "master"}}},
 
         {envy, ".*",
-         {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
+         {git, "https://github.com/manderson26/envy.git", {branch, "master"}}}
        ]}.
 
 {dev_only_deps, []}.


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Github has updated its security to disable the use of unencrypted git protocol.
https://github.blog/2021-09-01-improving-git-protocol-security-github/

This has cause issue when Automate notification service is trying to build.
https://buildkite.com/chef/chef-automate-main-nightly/builds/1075#22450580-dcb3-4af5-b6cc-f99c76001221
https://buildkite.com/chef/chef-automate-main-post-promote/builds/444

The branch we are working on to fix this in Automate:
https://github.com/chef/automate/tree/kallol/fix_notification_dependencies

This PR updates the dependencies to use `https` instead of `git`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
