### PR TITLE
Do not merge: jsonb support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
 {deps, [
         %% This is until a patch of ours gets merged into the main epgsql repo
         {epgsql, ".*",
-         {git, "https://github.com/chef/epgsql-1.git", {branch, "master"}}},
+         {git, "https://github.com/epgsql/epgsql.git", {branch, "master"}}},
 
         {pooler, ".*",
          {git, "https://github.com/chef/pooler.git", {branch, "master"}}},

--- a/src/sqerl_pgsql_client.erl
+++ b/src/sqerl_pgsql_client.erl
@@ -198,8 +198,9 @@ init(Config) ->
     %% and mark the connection as invalid.
     Opts = [ {database, Db},
              {port, Port},
-             {timeout, Timeout},
-             {req_timeout, Timeout + 100}
+             {timeout, Timeout}
+    %% TODO JSONB - re-sync and add this back in to epgsql
+    %%       {req_timeout, Timeout + 100}
              | ExtraOptions ],
     CTrans =
         case lists:keyfind(column_transforms, 1, Config) of


### PR DESCRIPTION
This repoints us to upstream epgsql for jsonb support, and updates the library for compatibility.

Note that we have our own timeout changes in chef/epgsql-1 that will need to be merged into upstream epgsql before we can move forward with this branch; o r we need to sync chef/epgsql-1 with upstream.